### PR TITLE
Fix jump

### DIFF
--- a/.github/workflows/dependent-bot-auto-merge.yml
+++ b/.github/workflows/dependent-bot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'Alex222222222222/rustcast'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/cache/src/cache/mod.rs
+++ b/cache/src/cache/mod.rs
@@ -180,18 +180,13 @@ impl Cache {
 
         info!("Starting download of {}", file_meta.location);
 
-        let mut bytes_downloaded = 0;
         while let Some(b) = response.next().await {
             let b = b?;
-            bytes_downloaded += b.len();
             tempfile_write_handle.write_all(&b).await?;
         }
 
-        info!("Downloaded {} bytes", bytes_downloaded);
         tempfile_write_handle.flush().await?;
         drop(tempfile_write_handle);
-
-        debug!("Writing meta file");
 
         let meta = Meta::new(path.into(), file_meta.clone(), self.freshness_lifetime);
         meta.to_file().await?;
@@ -207,7 +202,6 @@ impl Cache {
     }
 
     pub async fn get_file_meta(&self, resource: &str) -> Result<FileMetadata, Error> {
-        debug!("Fetching ETAG for {}", resource);
         self.file_downloader.get_meta(resource).await
     }
 

--- a/src/playlist/mod.rs
+++ b/src/playlist/mod.rs
@@ -14,4 +14,4 @@ pub use playlist_struct::{Playlist, PreparedFrame};
 const DEFAULT_FRAME_SIZE: usize = 2097152;
 
 /// maximum write ahead duration in milliseconds for the playlist
-const MAX_WRITE_AHEAD_DURATION: u128 = 300000;
+const MAX_WRITE_AHEAD_DURATION: u128 = 120000;

--- a/src/playlist/playlist_frame_stream.rs
+++ b/src/playlist/playlist_frame_stream.rs
@@ -85,8 +85,9 @@ impl Stream for PlaylistFrameStream {
                         Ok(Some(frame)) => {
                             self.current_stream_frame = frame.clone();
                             self.write_ahead_duration += frame.duration;
+                            let sleep_dur = frame.duration.floor();
                             self.waiting_pending_future = Some(Box::pin(tokio::time::sleep(
-                                std::time::Duration::from_millis(frame.duration.floor() as u64),
+                                std::time::Duration::from_millis(sleep_dur as u64),
                             )));
                             return Poll::Ready(Some(Ok(frame)));
                         }

--- a/src/playlist/playlist_struct.rs
+++ b/src/playlist/playlist_struct.rs
@@ -132,6 +132,20 @@ impl Playlist {
     pub async fn get_frame_with_id(&self, id: &ListenerID) -> Option<PreparedFrame> {
         self.listener_frame_data_db.get_frame_with_id(id).await
     }
+
+    /// Get the listener_id from the session_id, if the session_id is not found, return None
+    pub async fn get_listener_id_from_session_id(&self, session_id: &str) -> Option<usize> {
+        self.listener_frame_data_db
+            .get_listener_id_from_session_id(session_id)
+            .await
+    }
+
+    /// log session_id to listener_id
+    pub async fn log_session_id(&self, session_id: String, listener_id: usize) {
+        self.listener_frame_data_db
+            .log_session_id(session_id, listener_id)
+            .await;
+    }
 }
 
 /// A linked list of frames that is zero-copy and can be used to stream frames to a client.

--- a/src/shoutcast/mod.rs
+++ b/src/shoutcast/mod.rs
@@ -14,8 +14,8 @@ use request_handler::RequestHandler;
 
 #[derive(Debug)]
 pub struct ListenerID {
-    pub session_id: Option<String>,
     pub listener_id: usize,
+    pub session_id: Option<String>,
 }
 
 pub async fn listen(host: String, port: u16, playlists: Arc<HashMap<String, Arc<Playlist>>>) {


### PR DESCRIPTION
perf: increase listener session timeouts and optimize frame handling

- Increase session timeouts from stream duration to 5 minutes
- Fix session ID handling with proper caching
- Remove excessive debug logs from cache operations
- Decrease max write-ahead duration from 5 to 2 minutes