### PR TITLE
refactor: modernize playlist streaming architecture with async streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1741,7 @@ name = "rustcast"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bytes",
  "cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1", features = [
     "fs",
     "io-util",
 ] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 anyhow = "1"
 strum = { version = "0.27", features = ["derive"] }
 log = "0.4"
@@ -36,6 +36,7 @@ rand = "0.9"
 object_store = { version = "0.11", features = ["gcp", "aws", "azure", "http"] }
 moka = { version = "0.12", features = ["future"] }
 clap = { version = "4.5", features = ["derive"] }
+async-stream = "0.3"
 
 [dev-dependencies]
 static_assertions = "1.1"

--- a/derive_lazy_playlist_child/src/impl_playlist_child.rs
+++ b/derive_lazy_playlist_child/src/impl_playlist_child.rs
@@ -8,55 +8,14 @@ pub fn impl_playlist_child(name: &Ident, generics: &Generics) -> proc_macro2::To
     quote! {
         #[async_trait::async_trait]
         impl #impl_generics PlaylistChild for #name #ty_generics #where_clause{
-            /// current_title returns the title of current playing song
-            async fn current_title(&mut self) -> anyhow::Result<Option<std::sync::Arc<String>>> {
+            async fn stream_frame_with_meta(
+                &'_ mut self,
+            ) -> anyhow::Result<
+                std::pin::Pin<Box<dyn futures::Stream<Item = anyhow::Result<FrameWithMeta>> + Send + '_>>,
+            > {
                 self.init().await?;
                 if let Some(inner) = &mut self.inner {
-                    inner.current_title().await
-                } else {
-                    anyhow::bail!("inner is none")
-                }
-            }
-
-            /// Artist returns the artist which is currently playing.
-            async fn current_artist(&mut self) -> anyhow::Result<Option<std::sync::Arc<String>>> {
-                self.init().await?;
-                if let Some(inner) = &mut self.inner {
-                    inner.current_artist().await
-                } else {
-                    anyhow::bail!("inner is none")
-                }
-            }
-
-            /// return the current content type of the playlist
-            async fn content_type(&mut self) -> anyhow::Result<Option<std::sync::Arc<String>>> {
-                self.init().await?;
-                if let Some(inner) = &mut self.inner {
-                    inner.content_type().await
-                } else {
-                    anyhow::bail!("inner is none")
-                }
-            }
-
-            /// return the current byte_per_millisecond
-            async fn byte_per_millisecond(&mut self) -> anyhow::Result<Option<f64>> {
-                self.init().await?;
-                if let Some(inner) = &mut self.inner {
-                    inner.byte_per_millisecond().await
-                } else {
-                    anyhow::bail!("inner is none")
-                }
-            }
-
-            /// return a stream representing the current track, and the byte_per_millisecond
-            /// the stream should be closed when the track is finished
-            /// return none if the playlist is finished
-            async fn next_frame(
-                &mut self,
-            ) -> anyhow::Result<Option<bytes::Bytes>> {
-                self.init().await?;
-                if let Some(inner) = &mut self.inner {
-                    inner.next_frame().await
+                    inner.stream_frame_with_meta().await
                 } else {
                     anyhow::bail!("inner is none")
                 }
@@ -67,16 +26,6 @@ pub fn impl_playlist_child(name: &Ident, generics: &Generics) -> proc_macro2::To
                 self.init().await?;
                 if let Some(inner) = &mut self.inner {
                     inner.is_finished().await
-                } else {
-                    anyhow::bail!("inner is none")
-                }
-            }
-
-            /// reset the played status of the child
-            async fn reset(&mut self) -> anyhow::Result<()> {
-                self.init().await?;
-                if let Some(inner) = &mut self.inner {
-                    inner.reset().await
                 } else {
                     anyhow::bail!("inner is none")
                 }

--- a/derive_lazy_playlist_child/src/new_lazy_playlist_child.rs
+++ b/derive_lazy_playlist_child/src/new_lazy_playlist_child.rs
@@ -21,7 +21,7 @@ pub fn new_lazy_playlist_child(
     quote! {
         // The generated impl.
         impl #impl_generics #name #ty_generics #where_clause {
-            pub async fn new(#input) -> anyhow::Result<Self> {
+            pub fn new(#input) -> anyhow::Result<Self> {
                 Ok(#constructor)
             }
         }

--- a/src/config/playlist_config/mod.rs
+++ b/src/config/playlist_config/mod.rs
@@ -37,7 +37,7 @@ mod tests {
         // Verify the enum variant
         match config.child {
             PlaylistChildConfig::LocalFolder { folder, .. } => {
-                assert_eq!(folder, "/path/to/folder");
+                assert_eq!(*folder, "/path/to/folder");
             }
             _ => panic!("Expected LocalFolder variant"),
         }

--- a/src/config/playlist_config/playlist_child.rs
+++ b/src/config/playlist_config/playlist_child.rs
@@ -1,52 +1,54 @@
-#[derive(Debug, serde::Deserialize)]
+use std::sync::Arc;
+
+#[derive(Debug, serde::Deserialize, Clone)]
 pub enum PlaylistChildConfig {
     Silent,
     LocalFolder {
-        folder: String,
+        folder: Arc<String>,
         #[serde(default)]
         repeat: Option<bool>,
         #[serde(default)]
         shuffle: Option<bool>,
         #[serde(default)]
-        fail_over: Option<Box<PlaylistChildConfig>>,
+        fail_over: Option<Arc<PlaylistChildConfig>>,
     },
     LocalFiles {
-        files: Vec<String>,
+        files: Arc<Vec<Arc<String>>>,
         #[serde(default)]
         repeat: Option<bool>,
         #[serde(default)]
         shuffle: Option<bool>,
         #[serde(default)]
-        fail_over: Option<Box<PlaylistChildConfig>>,
+        fail_over: Option<Arc<PlaylistChildConfig>>,
     },
     RemoteFolder {
-        folder: String,
-        remote_client: String,
+        folder: Arc<String>,
+        remote_client: Arc<String>,
         #[serde(default)]
         repeat: Option<bool>,
         #[serde(default)]
         shuffle: Option<bool>,
         #[serde(default)]
-        fail_over: Option<Box<PlaylistChildConfig>>,
+        fail_over: Option<Arc<PlaylistChildConfig>>,
     },
     RemoteFiles {
-        files: Vec<String>,
+        files: Arc<Vec<Arc<String>>>,
         remote_client: String,
         #[serde(default)]
         repeat: Option<bool>,
         #[serde(default)]
         shuffle: Option<bool>,
         #[serde(default)]
-        fail_over: Option<Box<PlaylistChildConfig>>,
+        fail_over: Option<Arc<PlaylistChildConfig>>,
     },
     Playlists {
-        children: Box<Vec<PlaylistChildConfig>>,
+        children: Arc<Vec<Arc<PlaylistChildConfig>>>,
         #[serde(default)]
         repeat: Option<bool>,
         #[serde(default)]
         shuffle: Option<bool>,
         #[serde(default)]
-        fail_over: Option<Box<PlaylistChildConfig>>,
+        fail_over: Option<Arc<PlaylistChildConfig>>,
     },
 }
 #[cfg(test)]
@@ -72,7 +74,7 @@ mod tests {
         let config = PlaylistChildConfig::from_json(json).await.unwrap();
         match config {
             PlaylistChildConfig::LocalFolder { folder, .. } => {
-                assert_eq!(folder, "/path/to/folder")
+                assert_eq!(*folder, "/path/to/folder")
             }
             _ => panic!("Expected LocalFolder variant"),
         }
@@ -85,8 +87,8 @@ mod tests {
         match config {
             PlaylistChildConfig::LocalFiles { files, .. } => {
                 assert_eq!(files.len(), 2);
-                assert_eq!(files[0], "/path/to/file1.mp3");
-                assert_eq!(files[1], "/path/to/file2.mp3");
+                assert_eq!(*files[0], "/path/to/file1.mp3");
+                assert_eq!(*files[1], "/path/to/file2.mp3");
             }
             _ => panic!("Expected LocalFiles variant"),
         }
@@ -102,8 +104,8 @@ mod tests {
                 remote_client,
                 ..
             } => {
-                assert_eq!(folder, "bucket/folder");
-                assert_eq!(remote_client, "default");
+                assert_eq!(*folder, "bucket/folder");
+                assert_eq!(*remote_client, "default");
             }
             _ => panic!("Expected S3Folder variant"),
         }
@@ -120,8 +122,8 @@ mod tests {
                 ..
             } => {
                 assert_eq!(files.len(), 2);
-                assert_eq!(files[0], "bucket/file1.mp3");
-                assert_eq!(files[1], "bucket/file2.mp3");
+                assert_eq!(*files[0], "bucket/file1.mp3");
+                assert_eq!(*files[1], "bucket/file2.mp3");
                 assert_eq!(remote_client, "default");
             }
             _ => panic!("Expected S3Files variant"),
@@ -140,7 +142,7 @@ mod tests {
         let config = PlaylistChildConfig::from_json(json).await.unwrap();
         match config {
             PlaylistChildConfig::LocalFolder { folder, repeat, .. } => {
-                assert_eq!(folder, "/path/to/folder");
+                assert_eq!(*folder, "/path/to/folder");
                 assert_eq!(repeat, Some(true));
             }
             _ => panic!("Expected LocalFolder variant"),

--- a/src/file_provider/aws.rs
+++ b/src/file_provider/aws.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf, pin::Pin, sync::Arc, task::Poll};
 
 use async_trait::async_trait;
 use cache::AwsS3Downloader;
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use log::debug;
 use object_store::{ObjectStore, aws::AmazonS3Builder};
 use tokio::sync::Mutex;
@@ -54,8 +54,8 @@ impl FileProvider for AwsS3FileProvider {
 
     async fn list_files(
         &self,
-        path: Option<String>,
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send>> {
+        path: Option<&str>,
+    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send + Sync>> {
         debug!("list files in {:?}", path);
         let s =
             ObjectStoreListStream2FileProviderStream::new(self.object_store.clone(), path).await?;
@@ -63,8 +63,9 @@ impl FileProvider for AwsS3FileProvider {
     }
 }
 
-type StringOutPending =
-    Pin<Box<dyn futures::Future<Output = Option<anyhow::Result<String>>> + std::marker::Send>>;
+type StringOutPending = Pin<
+    Box<dyn futures::Future<Output = Option<anyhow::Result<String>>> + std::marker::Send + Sync>,
+>;
 
 struct ObjectStoreListStream2FileProviderStream {
     res: usize,
@@ -72,9 +73,9 @@ struct ObjectStoreListStream2FileProviderStream {
 }
 
 impl ObjectStoreListStream2FileProviderStream {
-    async fn new(s: Arc<dyn ObjectStore>, p: Option<String>) -> anyhow::Result<Self> {
+    async fn new(s: Arc<dyn ObjectStore>, p: Option<&str>) -> anyhow::Result<Self> {
         let p = match p {
-            Some(p) => Some(object_store::path::Path::parse(&p)?),
+            Some(p) => Some(object_store::path::Path::parse(p)?),
             None => None,
         };
         let (sender, res) = tokio::sync::mpsc::channel(1);
@@ -156,7 +157,7 @@ impl Stream for ObjectStoreListStream2FileProviderStream {
         }
 
         let r = get_res(self.res);
-        self.pending = Some(r.boxed());
+        self.pending = Some(Box::pin(r) as StringOutPending);
         cx.waker().wake_by_ref();
         Poll::Pending
     }

--- a/src/file_provider/local.rs
+++ b/src/file_provider/local.rs
@@ -53,8 +53,8 @@ impl FileProvider for LocalFileProvider {
 
     async fn list_files(
         &self,
-        path: Option<String>,
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send>> {
+        path: Option<&str>,
+    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send + Sync>> {
         let p = match path {
             Some(p) => PathBuf::from(p),
             None => PathBuf::from("."),
@@ -71,10 +71,14 @@ impl FileProvider for LocalFileProvider {
 }
 
 type Entries = Arc<
-    Mutex<Option<Box<dyn Stream<Item = tokio::io::Result<tokio::fs::DirEntry>> + Unpin + Send>>>,
+    Mutex<
+        Option<
+            Box<dyn Stream<Item = tokio::io::Result<tokio::fs::DirEntry>> + Unpin + Send + Sync>,
+        >,
+    >,
 >;
 type StringOutPending =
-    Pin<Box<dyn futures::Future<Output = Option<anyhow::Result<String>>> + Send>>;
+    Pin<Box<dyn futures::Future<Output = Option<anyhow::Result<String>>> + Send + Sync>>;
 
 struct MyReadDirStream {
     entries: Entries,

--- a/src/file_provider/mod.rs
+++ b/src/file_provider/mod.rs
@@ -47,6 +47,6 @@ pub trait FileProvider: Send + Sync {
     /// Returns iterator of file paths.
     async fn list_files(
         &self,
-        path: Option<String>,
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send>>;
+        path: Option<&str>,
+    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send + Sync>>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-// TODO cache x-playback-session-id
-
 use std::{collections::HashMap, sync::Arc};
 
 use clap::Parser;

--- a/src/playlist/playlist_child/impl_playlist_child_by_redirect_to_self_variable.rs
+++ b/src/playlist/playlist_child/impl_playlist_child_by_redirect_to_self_variable.rs
@@ -2,41 +2,18 @@ macro_rules! impl_playlist_child_by_redirect_to_self_variable {
     ($t:ty, $e:ident) => {
         #[async_trait]
         impl PlaylistChild for $t {
-            /// current_title returns the title of current playing song
-            async fn current_title(&mut self) -> anyhow::Result<Option<std::sync::Arc<String>>> {
-                self.$e.current_title().await
+            async fn stream_frame_with_meta(
+                &'_ mut self,
+            ) -> anyhow::Result<
+                std::pin::Pin<
+                    Box<dyn futures::Stream<Item = anyhow::Result<FrameWithMeta>> + Send + '_>,
+                >,
+            > {
+                self.$e.stream_frame_with_meta().await
             }
 
-            /// Artist returns the artist which is currently playing.
-            async fn current_artist(&mut self) -> anyhow::Result<Option<std::sync::Arc<String>>> {
-                self.$e.current_artist().await
-            }
-
-            /// return the current content type of the playlist
-            async fn content_type(&mut self) -> anyhow::Result<Option<std::sync::Arc<String>>> {
-                self.$e.content_type().await
-            }
-
-            /// return the current byte_per_millisecond
-            async fn byte_per_millisecond(&mut self) -> anyhow::Result<Option<f64>> {
-                self.$e.byte_per_millisecond().await
-            }
-
-            /// return a stream representing the current track, and the byte_per_millisecond
-            /// the stream should be closed when the track is finished
-            /// return none if the playlist is finished
-            async fn next_frame(&mut self) -> anyhow::Result<Option<Bytes>> {
-                self.$e.next_frame().await
-            }
-
-            /// check if the Playlist is finished
             async fn is_finished(&mut self) -> anyhow::Result<bool> {
                 self.$e.is_finished().await
-            }
-
-            /// reset the played status of the child
-            async fn reset(&mut self) -> anyhow::Result<()> {
-                self.$e.reset().await
             }
         }
     };

--- a/src/playlist/playlist_child/infinite_shuffle_stream.rs
+++ b/src/playlist/playlist_child/infinite_shuffle_stream.rs
@@ -1,0 +1,259 @@
+use std::{collections::LinkedList, pin::Pin, sync::Arc};
+
+use async_stream::stream;
+use futures::{Stream, StreamExt};
+use std::future::Future;
+
+pub type OriginalData2Stream<O, F, FP> = fn(
+    Arc<O>,
+    FP,
+) -> Pin<
+    Box<
+        dyn Future<Output = anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<F>> + Send>>>>
+            + Send,
+    >,
+>;
+
+const MAX_STORED_DATA: usize = 8;
+
+/// This is used to shuffle the stream infinitely,
+/// this is designed for the speed of shuffling, not the quality of shuffling.
+/// And in exchange for speed, the quality of shuffling is reduced, and the memory usage is increased.
+/// The best use case for this is when coming stream is large,
+/// and the normal vector shuffle is too slow.
+pub struct InfiniteShuffleStream<O, F, FP>
+where
+    O: Send + Sync + Unpin,
+    F: Send + Sync + Unpin,
+    FP: Send + Sync + Unpin + Clone,
+{
+    file_provider: FP,
+    repeat: bool,
+    /// A probability determine how messy the shuffle is, a higher value means less messy
+    /// 1.0 means no shuffle, the default value is 0.3
+    shuffule_probability: f64,
+    /// up_probability = shuffule_probability + (1.0 - shuffule_probability) / 2
+    /// stored for optimization
+    up_probability: f64,
+    original_data: Arc<O>,
+    original_data_2_stream: OriginalData2Stream<O, F, FP>,
+}
+
+impl<O, F, FP> InfiniteShuffleStream<O, F, FP>
+where
+    O: Send + Sync + Unpin,
+    F: Send + Sync + Unpin,
+    FP: Send + Sync + Unpin + Clone,
+{
+    pub fn new(
+        file_provider: FP,
+        original_data: Arc<O>,
+        repeat: bool,
+        shuffle: bool,
+        original_data_2_stream: OriginalData2Stream<O, F, FP>,
+    ) -> Self {
+        let shuffule_probability = if shuffle { 0.3 } else { 1.0 };
+        let up_probability = shuffule_probability + (1.0 - shuffule_probability) / 2.0;
+
+        Self {
+            file_provider,
+            repeat,
+            shuffule_probability,
+            up_probability,
+            original_data,
+            original_data_2_stream,
+        }
+    }
+
+    /// return a stream that will shuffle the data infinitely
+    pub fn stream(&'_ self) -> impl Stream<Item = anyhow::Result<F>> + Send + '_ {
+        let s = stream! {
+            let mut stored_data = LinkedList::new();
+            'outer: loop {
+                let mut stream = (self.original_data_2_stream)(self.original_data.clone(), self.file_provider.clone()).await?;
+                'inner: loop {
+                    match stream.next().await {
+                        Some(Ok(data)) => {
+                            // rand a value between 0.0 and 1.0
+                            let rand_value = rand::random::<f64>();
+                            let data = if rand_value < self.shuffule_probability {
+                                yield Ok(data);
+                                continue;
+                            } else if rand_value < self.up_probability {
+                                stored_data.push_front(data);
+                                if stored_data.len() > MAX_STORED_DATA {
+                                    stored_data.pop_back()
+                                } else {
+                                    None
+                                }
+                            } else {
+                                stored_data.push_back(data);
+                                if stored_data.len() > MAX_STORED_DATA {
+                                    stored_data.pop_front()
+                                } else {
+                                    None
+                                }
+                            };
+
+                            if let Some(data) = data {
+                                yield Ok(data);
+                            }
+                        }
+                        Some(Err(err)) => {
+                            yield Err(err);
+                        }
+                        None => {
+                            if self.repeat {
+                                break 'inner;
+                            } else if stored_data.is_empty() {
+                                break 'outer;
+                            } else {
+                                // consume all data in stored_data
+                                let rand_value = rand::random::<f64>();
+                                if rand_value < 0.5 {
+                                    yield Ok(stored_data.pop_front().unwrap());
+                                } else {
+                                    yield Ok(stored_data.pop_back().unwrap());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::pin_mut;
+    use std::collections::HashSet;
+
+    #[derive(Clone)]
+    struct MockFileProvider;
+
+    struct MockOriginalData;
+
+    fn mock_data_stream(
+        _original_data: Arc<MockOriginalData>,
+        _fp: MockFileProvider,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = anyhow::Result<
+                        Pin<Box<dyn Stream<Item = anyhow::Result<i32>> + Send>>,
+                    >,
+                > + Send,
+        >,
+    > {
+        let values = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let stream: Pin<Box<dyn Stream<Item = anyhow::Result<i32>> + Send>> =
+            Box::pin(futures::stream::iter(values.into_iter().map(Ok)));
+        let stream = async move || Ok(stream);
+        let stream = (stream)();
+        Box::pin(stream)
+    }
+
+    #[tokio::test]
+    async fn test_stream_no_repeat_no_shuffle() {
+        let original_data = Arc::new(MockOriginalData);
+        let file_provider = MockFileProvider;
+
+        let shuffle_stream = InfiniteShuffleStream::new(
+            file_provider,
+            original_data,
+            false, // no repeat
+            false, // no shuffle
+            mock_data_stream as OriginalData2Stream<MockOriginalData, i32, MockFileProvider>,
+        );
+
+        let stream = shuffle_stream.stream();
+        pin_mut!(stream);
+
+        let mut results = Vec::new();
+
+        while let Some(item) = stream.next().await {
+            results.push(item.unwrap());
+        }
+
+        // When no shuffle is enabled, we expect the items in their original order
+        // Since shuffle probability is set to 1.0
+        assert_eq!(results, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    }
+
+    #[tokio::test]
+    async fn test_stream_with_repeat() {
+        let original_data = Arc::new(MockOriginalData);
+        let file_provider = MockFileProvider;
+
+        let shuffle_stream = InfiniteShuffleStream::new(
+            file_provider,
+            original_data,
+            true,  // repeat
+            false, // no shuffle
+            mock_data_stream,
+        );
+
+        let stream = shuffle_stream.stream();
+        pin_mut!(stream);
+
+        let mut results = Vec::new();
+
+        // With repeat enabled, the stream will continue indefinitely
+        // So we only take the first 20 items
+        for _ in 0..20 {
+            if let Some(item) = stream.next().await {
+                results.push(item.unwrap());
+            }
+        }
+
+        // We should get the sequence repeated
+        assert_eq!(results[0..10], vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(results[10..20], vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    }
+
+    #[tokio::test]
+    async fn test_stream_with_shuffle() {
+        let original_data = Arc::new(MockOriginalData);
+        let file_provider = MockFileProvider;
+
+        let shuffle_stream = InfiniteShuffleStream::new(
+            file_provider,
+            original_data,
+            false, // no repeat
+            true,  // shuffle
+            mock_data_stream,
+        );
+
+        let stream = shuffle_stream.stream();
+        pin_mut!(stream);
+
+        let mut results = Vec::new();
+
+        while let Some(item) = stream.next().await {
+            results.push(item.unwrap());
+        }
+
+        // With shuffle enabled, we expect:
+        // 1. All original items should still be present
+        // 2. The order should likely be different from the original
+
+        // Check if all original items are present
+        let result_set: HashSet<_> = results.iter().collect();
+        assert_eq!(result_set.len(), 10);
+        for i in 1..=10 {
+            assert!(result_set.contains(&i));
+        }
+
+        // It's possible but unlikely that the shuffle produces the original order
+        // This is a weak test but better than nothing
+        let original_order = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        assert!(
+            results.len() == original_order.len(),
+            "Expected same number of items"
+        );
+    }
+}

--- a/src/playlist/playlist_child/mod.rs
+++ b/src/playlist/playlist_child/mod.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 #[macro_use]
 mod impl_playlist_child_by_redirect_to_self_variable;
 
+mod infinite_shuffle_stream;
 mod local;
 mod playlist_child_list;
 
@@ -13,50 +14,24 @@ use bytes::Bytes;
 pub use local::*;
 pub use playlist_child_list::PlaylistChildList;
 
+#[derive(Clone)]
+pub struct FrameWithMeta {
+    pub frame: Bytes,
+    pub title: Arc<String>,
+    pub artist: Arc<String>,
+    pub content_type: Arc<String>,
+    /// duration of the frame in milliseconds
+    pub duration: f64,
+}
+
 #[async_trait]
 pub trait PlaylistChild: Sync + Send {
-    /// current_title returns the title of current playing song
-    /// return none if the playlist is finished
-    async fn current_title(&mut self) -> anyhow::Result<Option<Arc<String>>>;
-
-    /// Artist returns the artist which is currently playing.
-    /// return none if the playlist is finished
-    async fn current_artist(&mut self) -> anyhow::Result<Option<Arc<String>>>;
-
-    /// return the current content type of the playlist
-    /// return none if the playlist is finished
-    async fn content_type(&mut self) -> anyhow::Result<Option<Arc<String>>>;
-
-    /// return the current byte_per_millisecond
-    /// return none if the playlist is finished
-    async fn byte_per_millisecond(&mut self) -> anyhow::Result<Option<f64>>;
-
-    /// return a stream representing the current track, and the byte_per_millisecond
-    /// the stream should be closed when the track is finished
-    /// return none if the playlist is finished
-    async fn next_frame(&mut self) -> anyhow::Result<Option<Bytes>>;
-
-    async fn next_frame_with_meta(
-        &mut self,
-    ) -> anyhow::Result<Option<(Bytes, Arc<String>, Arc<String>)>> {
-        let frame = match self.next_frame().await? {
-            Some(frame) => frame,
-            None => return Ok(None),
-        };
-        let title = match self.current_title().await? {
-            Some(title) => title,
-            None => return Ok(None),
-        };
-        let artist = match self.current_artist().await? {
-            Some(artist) => artist,
-            None => return Ok(None),
-        };
-        Ok(Some((frame, title, artist)))
-    }
+    async fn stream_frame_with_meta(
+        &'_ mut self,
+    ) -> anyhow::Result<
+        std::pin::Pin<Box<dyn futures::Stream<Item = anyhow::Result<FrameWithMeta>> + Send + '_>>,
+    >;
 
     /// check if the Playlist is finished
     async fn is_finished(&mut self) -> anyhow::Result<bool>;
-
-    /// reset the played status of the child
-    async fn reset(&mut self) -> anyhow::Result<()>;
 }

--- a/src/playlist/playlist_frame_stream.rs
+++ b/src/playlist/playlist_frame_stream.rs
@@ -84,8 +84,8 @@ impl Stream for PlaylistFrameStream {
                     match data {
                         Ok(Some(frame)) => {
                             self.current_stream_frame = frame.clone();
-                            self.write_ahead_duration += frame.duration;
-                            let sleep_dur = frame.duration.floor();
+                            self.write_ahead_duration += frame.frame_with_meta.duration;
+                            let sleep_dur = frame.frame_with_meta.duration.floor();
                             self.waiting_pending_future = Some(Box::pin(tokio::time::sleep(
                                 std::time::Duration::from_millis(sleep_dur as u64),
                             )));

--- a/src/shoutcast/request_handler.rs
+++ b/src/shoutcast/request_handler.rs
@@ -162,28 +162,22 @@ impl RequestHandler {
                     return Ok(());
                 }
             };
-            self.title = frame.title.clone();
-            self.artist = frame.artist.clone();
+            self.title = frame.frame_with_meta.title.clone();
+            self.artist = frame.frame_with_meta.artist.clone();
 
             self.playlist
                 .log_current_frame(&self.id, frame.clone())
                 .await;
 
             bytes_before_next_meta_data = self
-                .write_frame(frame.frame, bytes_before_next_meta_data)
+                .write_frame(frame.frame_with_meta.frame, bytes_before_next_meta_data)
                 .await?;
         }
     }
 
     /// writeStreamStartResponse writes the start response to the client.
     async fn write_stream_start_response(&mut self) -> anyhow::Result<()> {
-        let content_type = match self.playlist.content_type().await? {
-            Some(content_type) => content_type,
-            None => {
-                debug!("content type is none");
-                return Err(anyhow::anyhow!("content type is none"));
-            }
-        };
+        let content_type = self.playlist.get_content_type().await;
 
         debug!("write stream start response");
         self.sink.send("ICY 200 OK\r\n").await?;


### PR DESCRIPTION
- Convert PlaylistChild to use streaming API with async-stream
- Replace individual callbacks with unified stream_frame_with_meta method
- Add InfiniteShuffleStream for better memory-efficient shuffling
- Make config use Arc<String> for more efficient sharing
- Remove manual track management in favor of streams
- Switch initialization functions from async to sync where possible
- Update file provider interfaces to support Sync trait bound