### PR TITLE
refactor: modernize file stream handling with async-stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ name = "cache"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bytes",
  "chrono",

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -27,9 +27,5 @@ bytes = "*"
 tokio-stream = "*"
 futures = { version = "*", features = ["thread-pool"] }
 tokio-util = { version = "0.7", features = ["codec", "rt", "io", "net"] }
-object_store = { version = "*", features = [
-    "gcp",
-    "aws",
-    "azure",
-    "http",
-] }
+object_store = { version = "*", features = ["gcp", "aws", "azure", "http"] }
+async-stream = "*"

--- a/cache/src/file_downloader/impl_object_store/gcp.rs
+++ b/cache/src/file_downloader/impl_object_store/gcp.rs
@@ -1,5 +1,6 @@
-use std::{pin::Pin, sync::Arc};
+use std::sync::Arc;
 
+use async_stream::stream;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
@@ -82,13 +83,19 @@ impl FileDownloader for GcpDownloader {
     async fn get_file(
         &self,
         path: &str,
-    ) -> anyhow::Result<Box<dyn Stream<Item = Result<bytes::Bytes, Error>> + Unpin + Send>, Error>
+    ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<bytes::Bytes, Error>> + Send>>, Error>
     {
         let path = object_store::path::Path::parse(path)?;
         match self.object_store.get(&path).await {
-            Ok(file) => Ok(Box::new(ObjectStoreFileStream2FileProviderStream(
-                file.into_stream(),
-            ))),
+            Ok(file) => {
+                let s = stream! {
+                    let mut stream = file.into_stream();
+                    while let Some(bytes) = stream.next().await {
+                        yield bytes.map_err(|e| e.into());
+                    }
+                };
+                Ok(Box::pin(s))
+            }
             Err(object_store::Error::NotFound { .. }) => {
                 Err(Error::ResourceNotFound(path.to_string()))
             }
@@ -116,33 +123,5 @@ impl FileDownloader for GcpDownloader {
 
     fn hash(&self) -> Bytes {
         self.hash.clone()
-    }
-}
-
-struct ObjectStoreFileStream2FileProviderStream(
-    Pin<
-        Box<
-            (
-                dyn futures::Stream<Item = Result<bytes::Bytes, object_store::Error>>
-                    + std::marker::Send
-                    + 'static
-            ),
-        >,
-    >,
-);
-
-impl Stream for ObjectStoreFileStream2FileProviderStream {
-    type Item = Result<bytes::Bytes, Error>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        match self.0.poll_next_unpin(cx) {
-            std::task::Poll::Ready(Some(Ok(bytes))) => std::task::Poll::Ready(Some(Ok(bytes))),
-            std::task::Poll::Ready(Some(Err(e))) => std::task::Poll::Ready(Some(Err(e.into()))),
-            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-            std::task::Poll::Pending => std::task::Poll::Pending,
-        }
     }
 }

--- a/cache/src/file_downloader/local_downloader.rs
+++ b/cache/src/file_downloader/local_downloader.rs
@@ -13,8 +13,8 @@ impl super::FileDownloader for LocalDownloader {
     /// Returns a stream of bytes if the file exists, otherwise None.
     async fn get_file(
         &self,
-        _: &str,
-    ) -> anyhow::Result<Box<dyn Stream<Item = Result<bytes::Bytes, Error>> + Unpin + Send>, Error>
+        _path: &str,
+    ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<bytes::Bytes, Error>> + Send>>, Error>
     {
         // This function should never be called for the local downloader.
         Err(Error::NotImplemented)

--- a/cache/src/file_downloader/mod.rs
+++ b/cache/src/file_downloader/mod.rs
@@ -33,7 +33,7 @@ pub trait FileDownloader: Send + Sync {
     async fn get_file(
         &self,
         path: &str,
-    ) -> anyhow::Result<Box<dyn Stream<Item = Result<bytes::Bytes, Error>> + Unpin + Send>, Error>;
+    ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<bytes::Bytes, Error>> + Send>>, Error>;
 
     /// Get metadata for a file from the file provider.
     /// Returns ResourceNotFound error if the file does not exist.

--- a/src/file_provider/aws.rs
+++ b/src/file_provider/aws.rs
@@ -1,13 +1,11 @@
-use std::{collections::HashMap, path::PathBuf, pin::Pin, sync::Arc, task::Poll};
+use std::{path::PathBuf, sync::Arc};
 
+use async_stream::stream;
 use async_trait::async_trait;
 use cache::AwsS3Downloader;
 use futures::{Stream, StreamExt};
 use log::debug;
 use object_store::{ObjectStore, aws::AmazonS3Builder};
-use tokio::sync::Mutex;
-
-use crate::CONTEXT;
 
 use super::FileProvider;
 
@@ -52,113 +50,26 @@ impl FileProvider for AwsS3FileProvider {
         Ok(Some(meta))
     }
 
-    async fn list_files(
-        &self,
-        path: Option<&str>,
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send + Sync>> {
+    async fn list_files<'s, 'p>(
+        &'s self,
+        path: Option<&'p str>,
+    ) -> anyhow::Result<std::pin::Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send + 'p>>>
+    where
+        's: 'p,
+    {
         debug!("list files in {:?}", path);
-        let s =
-            ObjectStoreListStream2FileProviderStream::new(self.object_store.clone(), path).await?;
-        Ok(Box::new(s))
-    }
-}
+        let s = stream! {
+            let p = match path {
+                Some(p) => Some(object_store::path::Path::parse(p)?),
+                None => None,
+            };
+            let mut s = self.object_store.list(p.as_ref());
 
-type StringOutPending = Pin<
-    Box<dyn futures::Future<Output = Option<anyhow::Result<String>>> + std::marker::Send + Sync>,
->;
-
-struct ObjectStoreListStream2FileProviderStream {
-    res: usize,
-    pending: Option<StringOutPending>,
-}
-
-impl ObjectStoreListStream2FileProviderStream {
-    async fn new(s: Arc<dyn ObjectStore>, p: Option<&str>) -> anyhow::Result<Self> {
-        let p = match p {
-            Some(p) => Some(object_store::path::Path::parse(p)?),
-            None => None,
-        };
-        let (sender, res) = tokio::sync::mpsc::channel(1);
-        tokio::spawn(async move {
-            let mut s = s.list(p.as_ref());
             while let Some(meta) = s.next().await {
-                if let Err(e) = sender
-                    .send(meta.map(|m| m.location.to_string()).map_err(|e| e.into()))
-                    .await
-                {
-                    log::error!("failed to send file path: {}", e);
-                    break;
-                }
+                yield meta.map(|m| m.location.to_string()).map_err(|e| e.into());
             }
-        });
-        let id = CONTEXT.get_id().await;
-        insert_res(id, res).await;
-        Ok(Self {
-            res: id,
-            pending: None,
-        })
-    }
-}
+        };
 
-struct ResMap(Mutex<HashMap<usize, tokio::sync::mpsc::Receiver<anyhow::Result<String>>>>);
-
-impl ResMap {
-    fn new() -> Self {
-        Self(Mutex::new(HashMap::new()))
-    }
-}
-
-static RES_MAP: once_cell::sync::Lazy<ResMap> = once_cell::sync::Lazy::new(ResMap::new);
-
-fn remove_id(id: usize) {
-    tokio::spawn(async move {
-        let mut map = RES_MAP.0.lock().await;
-        map.remove(&id);
-    });
-}
-
-async fn insert_res(id: usize, res: tokio::sync::mpsc::Receiver<anyhow::Result<String>>) {
-    let mut map = RES_MAP.0.lock().await;
-    map.insert(id, res);
-}
-
-async fn get_res(id: usize) -> Option<anyhow::Result<String>> {
-    let mut map = RES_MAP.0.lock().await;
-    let r = map.get_mut(&id);
-    if let Some(r) = r {
-        r.recv().await
-    } else {
-        None
-    }
-}
-
-impl Drop for ObjectStoreListStream2FileProviderStream {
-    fn drop(&mut self) {
-        remove_id(self.res);
-    }
-}
-
-impl Stream for ObjectStoreListStream2FileProviderStream {
-    type Item = anyhow::Result<String>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        if let Some(ref mut future) = self.pending {
-            // Poll the future and check if it's ready
-            match future.as_mut().poll(cx) {
-                Poll::Ready(e) => {
-                    self.pending = None; // Reset future
-                    return Poll::Ready(e);
-                }
-                Poll::Pending => return Poll::Pending, // Still waiting
-            }
-        }
-
-        let r = get_res(self.res);
-        self.pending = Some(Box::pin(r) as StringOutPending);
-        cx.waker().wake_by_ref();
-        Poll::Pending
+        Ok(Box::pin(s))
     }
 }

--- a/src/file_provider/gcp.rs
+++ b/src/file_provider/gcp.rs
@@ -1,13 +1,11 @@
-use std::{collections::HashMap, path::PathBuf, pin::Pin, sync::Arc, task::Poll};
+use std::{path::PathBuf, sync::Arc};
 
+use async_stream::stream;
 use async_trait::async_trait;
 use cache::GcpDownloader;
 use futures::{Stream, StreamExt};
 use log::debug;
 use object_store::ObjectStore;
-use tokio::sync::Mutex;
-
-use crate::CONTEXT;
 
 use super::FileProvider;
 
@@ -53,114 +51,26 @@ impl FileProvider for GoogleCouldStorageFileProvider {
         };
         Ok(Some(meta))
     }
-
-    async fn list_files(
-        &self,
-        path: Option<&str>,
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send + Sync>> {
+    async fn list_files<'s, 'p>(
+        &'s self,
+        path: Option<&'p str>,
+    ) -> anyhow::Result<std::pin::Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send + 'p>>>
+    where
+        's: 'p,
+    {
         debug!("list files in {:?}", path);
-        let s =
-            ObjectStoreListStream2FileProviderStream::new(self.object_store.clone(), path).await?;
-        Ok(Box::new(s))
-    }
-}
+        let s = stream! {
+            let p = match path {
+                Some(p) => Some(object_store::path::Path::parse(p)?),
+                None => None,
+            };
+            let mut s = self.object_store.list(p.as_ref());
 
-type StringOutPending = Pin<
-    Box<dyn futures::Future<Output = Option<anyhow::Result<String>>> + std::marker::Send + Sync>,
->;
-
-struct ObjectStoreListStream2FileProviderStream {
-    res: usize,
-    pending: Option<StringOutPending>,
-}
-
-impl ObjectStoreListStream2FileProviderStream {
-    async fn new(s: Arc<dyn ObjectStore>, p: Option<&str>) -> anyhow::Result<Self> {
-        let p = match p {
-            Some(p) => Some(object_store::path::Path::parse(p)?),
-            None => None,
-        };
-        let (sender, res) = tokio::sync::mpsc::channel(1);
-        tokio::spawn(async move {
-            let mut s = s.list(p.as_ref());
             while let Some(meta) = s.next().await {
-                if let Err(e) = sender
-                    .send(meta.map(|m| m.location.to_string()).map_err(|e| e.into()))
-                    .await
-                {
-                    log::error!("failed to send file path: {}", e);
-                    break;
-                }
+                yield meta.map(|m| m.location.to_string()).map_err(|e| e.into());
             }
-        });
-        let id = CONTEXT.get_id().await;
-        insert_res(id, res).await;
-        Ok(Self {
-            res: id,
-            pending: None,
-        })
-    }
-}
+        };
 
-struct ResMap(Mutex<HashMap<usize, tokio::sync::mpsc::Receiver<anyhow::Result<String>>>>);
-
-impl ResMap {
-    fn new() -> Self {
-        Self(Mutex::new(HashMap::new()))
-    }
-}
-
-static RES_MAP: once_cell::sync::Lazy<ResMap> = once_cell::sync::Lazy::new(ResMap::new);
-
-fn remove_id(id: usize) {
-    tokio::spawn(async move {
-        let mut map = RES_MAP.0.lock().await;
-        map.remove(&id);
-    });
-}
-
-async fn insert_res(id: usize, res: tokio::sync::mpsc::Receiver<anyhow::Result<String>>) {
-    let mut map = RES_MAP.0.lock().await;
-    map.insert(id, res);
-}
-
-async fn get_res(id: usize) -> Option<anyhow::Result<String>> {
-    let mut map = RES_MAP.0.lock().await;
-    let r = map.get_mut(&id);
-    if let Some(r) = r {
-        r.recv().await
-    } else {
-        None
-    }
-}
-
-impl Drop for ObjectStoreListStream2FileProviderStream {
-    fn drop(&mut self) {
-        remove_id(self.res);
-    }
-}
-
-impl Stream for ObjectStoreListStream2FileProviderStream {
-    type Item = anyhow::Result<String>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        if let Some(ref mut future) = self.pending {
-            // Poll the future and check if it's ready
-            match future.as_mut().poll(cx) {
-                Poll::Ready(e) => {
-                    self.pending = None; // Reset future
-                    return Poll::Ready(e);
-                }
-                Poll::Pending => return Poll::Pending, // Still waiting
-            }
-        }
-
-        let r = get_res(self.res);
-        self.pending = Some(Box::pin(r) as StringOutPending);
-        cx.waker().wake_by_ref();
-        Poll::Pending
+        Ok(Box::pin(s))
     }
 }

--- a/src/file_provider/mod.rs
+++ b/src/file_provider/mod.rs
@@ -45,8 +45,10 @@ pub trait FileProvider: Send + Sync {
 
     /// List files in a directory.
     /// Returns iterator of file paths.
-    async fn list_files(
-        &self,
-        path: Option<&str>,
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<String>> + Unpin + Send + Sync>>;
+    async fn list_files<'s, 'p>(
+        &'s self,
+        path: Option<&'p str>,
+    ) -> anyhow::Result<std::pin::Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send + 'p>>>
+    where
+        's: 'p;
 }


### PR DESCRIPTION
- Replace custom stream implementations with async-stream
- Add async-stream as a dependency
- Simplify file stream handling in AWS and GCP downloaders
- Update list_files signature to be lifetime-aware
- Remove manual state tracking and custom stream impls
- Streamline directory traversal in local provider