### PR TITLE
ci: remove dependency name check from auto-merge workflow

### DIFF
--- a/.github/workflows/dependent-bot-auto-merge.yml
+++ b/.github/workflows/dependent-bot-auto-merge.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if: contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
- Allow all dependabot PRs to be auto-merged
- Keep patch version restriction