### PR TITLE
feat: add recursive option for playlist child

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Supported `playlist child` types:
   - `folder`: Path to the local folder containing audio files
   - `repeat`: Whether to loop the playlist when finished (optional), default is `false`
   - `shuffle`: Whether to randomize the playback order (optional), default is `false`
+  - `recursive`: Whether to include files in subdirectories (optional), default is `false`
   - `fail_over`: Alternative playlist to use if this source fails (optional), the object must be a `playlist child` object.
 
 ```json
@@ -199,6 +200,7 @@ Supported `playlist child` types:
     "folder": "/path/to/music",
     "repeat": true,
     "shuffle": true,
+    "recursive": true,
     "fail_over": {
       "LocalFolder": {
         "folder": "/path/to/backup"
@@ -236,6 +238,7 @@ Supported `playlist child` types:
   - `remote_client`: Name of the configured remote storage provider
   - `repeat`: Whether to loop the playlist when finished (optional), default is `false`
   - `shuffle`: Whether to randomize the playback order (optional), default is `false`
+  - `recursive`: Whether to include files in subdirectories (optional), default is `false`
   - `fail_over`: Alternative playlist to use if this source fails (optional), the object must be a `playlist child` object.
 
 ```json

--- a/src/config/playlist_config/playlist_child.rs
+++ b/src/config/playlist_config/playlist_child.rs
@@ -10,6 +10,8 @@ pub enum PlaylistChildConfig {
         #[serde(default)]
         shuffle: Option<bool>,
         #[serde(default)]
+        recursive: Option<bool>,
+        #[serde(default)]
         fail_over: Option<Arc<PlaylistChildConfig>>,
     },
     LocalFiles {
@@ -28,6 +30,8 @@ pub enum PlaylistChildConfig {
         repeat: Option<bool>,
         #[serde(default)]
         shuffle: Option<bool>,
+        #[serde(default)]
+        recursive: Option<bool>,
         #[serde(default)]
         fail_over: Option<Arc<PlaylistChildConfig>>,
     },

--- a/src/file_provider/aws.rs
+++ b/src/file_provider/aws.rs
@@ -1,6 +1,5 @@
 use std::{path::PathBuf, sync::Arc};
 
-use async_stream::stream;
 use async_trait::async_trait;
 use cache::AwsS3Downloader;
 use futures::{Stream, StreamExt};
@@ -53,22 +52,31 @@ impl FileProvider for AwsS3FileProvider {
     async fn list_files<'s, 'p>(
         &'s self,
         path: Option<&'p str>,
+        recursive: bool,
     ) -> anyhow::Result<std::pin::Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send + 'p>>>
     where
         's: 'p,
     {
         debug!("list files in {:?}", path);
-        let s = stream! {
-            let p = match path {
-                Some(p) => Some(object_store::path::Path::parse(p)?),
-                None => None,
-            };
-            let mut s = self.object_store.list(p.as_ref());
-
-            while let Some(meta) = s.next().await {
-                yield meta.map(|m| m.location.to_string()).map_err(|e| e.into());
-            }
+        let p = match path {
+            Some(p) => Some(object_store::path::Path::parse(p)?),
+            None => None,
         };
+        let s = if recursive {
+            // the list method is recursive
+            self.object_store.list(p.as_ref())
+        } else {
+            // the list_with_delimiter method is not recursive
+            let s = self
+                .object_store
+                .list_with_delimiter(p.as_ref())
+                .await?
+                .objects;
+            let s = futures::stream::iter(s).map(Ok);
+            Box::pin(s)
+        };
+
+        let s = s.map(|m| m.map(|r| r.location.to_string()).map_err(|e| e.into()));
 
         Ok(Box::pin(s))
     }

--- a/src/file_provider/local.rs
+++ b/src/file_provider/local.rs
@@ -53,6 +53,7 @@ impl FileProvider for LocalFileProvider {
     async fn list_files<'s, 'p>(
         &'s self,
         path: Option<&'p str>,
+        recursive: bool,
     ) -> anyhow::Result<std::pin::Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send + 'p>>>
     where
         's: 'p,
@@ -87,7 +88,9 @@ impl FileProvider for LocalFileProvider {
                         let f = f;
                         let t = f.file_type().await?;
                         if t.is_dir() {
-                            dirs.push_back(f.path());
+                            if recursive {
+                                dirs.push_back(f.path());
+                            }
                         } else {
                             yield Ok(f.path().to_string_lossy().to_string());
                         }

--- a/src/file_provider/mod.rs
+++ b/src/file_provider/mod.rs
@@ -48,6 +48,7 @@ pub trait FileProvider: Send + Sync {
     async fn list_files<'s, 'p>(
         &'s self,
         path: Option<&'p str>,
+        recursive: bool,
     ) -> anyhow::Result<std::pin::Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send + 'p>>>
     where
         's: 'p;

--- a/src/playlist/from_config.rs
+++ b/src/playlist/from_config.rs
@@ -35,13 +35,13 @@ async fn build_playlist_child_from_config(
              folder,
              repeat,
              shuffle,
+             recursive,
              // TODO add fail_over functionality
-             // TODO add recursive find file functionality
              ..
          } => {
              let file_provider = Arc::new(LocalFileProvider::new());
              Box::new(
-                 crate::playlist::LocalFolder::new(folder, repeat, shuffle, file_provider)?,
+                 crate::playlist::LocalFolder::new(folder, repeat, shuffle, recursive, file_provider)?,
              )
          }
 
@@ -53,7 +53,7 @@ async fn build_playlist_child_from_config(
                  crate::playlist::LocalFileTrackList::new(files, repeat, shuffle, file_provider)?,
              )
          },
-         PlaylistChildConfig::RemoteFolder { folder, remote_client, repeat, shuffle, ..
+         PlaylistChildConfig::RemoteFolder { folder, remote_client, repeat, shuffle, recursive, ..
              // TODO add fail_over functionality
          } => {
              let file_provider = match file_provider.get(remote_client.as_str()){
@@ -61,7 +61,7 @@ async fn build_playlist_child_from_config(
                  None => return Err(anyhow::anyhow!("No file provider found for {}", remote_client)),
              };
              Box::new(
-                 crate::playlist::LocalFolder::new(folder, repeat, shuffle, file_provider)?,
+                 crate::playlist::LocalFolder::new(folder, repeat, shuffle,recursive, file_provider)?,
              )
          },
          PlaylistChildConfig::RemoteFiles { files, remote_client, repeat, shuffle, ..


### PR DESCRIPTION
- Add `recursive` field to playlist child config
- Update file providers to handle recursive listing
- Modify LocalFolder to support recursive file inclusion