### PR TITLE
feat: add cache directory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ Options:
           Print version
 ```
 
+### Configuration Fields
+
+- `playlists`: Configuration for playlists, check [Playlists Configuration](#playlists-configuration)
+- `file_provider`: Configuration for file providers, check [File Provider Configuration](#file-provider-configuration)
+- `outputs`: Configuration for outputs, check [Output Configuration](#output-configuration)
+- `log_level`: Log level for the application, default is `info` (optional). Possible values: `off`, `error`, `warn`, `info`, `debug`, `trace`.
+- `log_file`: Log file path(s) for the application, default is `stdout` (optional). Can be specified multiple times.
+- `cache_dir`: Directory to store cached audio files when use remote file source (optional). On Unix like system, default to the `cache` subdir of `TMPDIR` environment variable if it is set, otherwise the value is OS-specific:
+  - On Darwin-based OSes (macOS, iOS, etc) it default to the `cache` subdir of the directory provided by confstr(_CS_DARWIN_USER_TEMP_DIR, ...), as recommended by Apple’s security guidelines.
+  - On all other unix-based OSes, it default to /tmp/cache.
+> Note: the default value of `cache_dir` get from rust `std::env::temp_dir()`,
+> for more information, please refer to [std::env::temp_dir](https://doc.rust-lang.org/std/env/fn.temp_dir.html)
+
 ### Playlists Configuration
 
 Playlists consist of maps where the key is used in the later definition of outputs,

--- a/cache/src/cache/cache_builder.rs
+++ b/cache/src/cache/cache_builder.rs
@@ -58,13 +58,10 @@ impl CacheBuilder {
 
     /// Build the `Cache` object.
     pub async fn build(self) -> Result<Cache, Error> {
-        let dir = self.config.dir.unwrap_or_else(|| {
-            if let Some(dir_str) = env::var_os("RUST_CACHED_PATH_ROOT") {
-                PathBuf::from(dir_str)
-            } else {
-                env::temp_dir().join("cache/")
-            }
-        });
+        let dir = self
+            .config
+            .dir
+            .unwrap_or_else(|| env::temp_dir().join("cache/"));
         tokio::fs::create_dir_all(&dir).await?;
         Ok(Cache {
             dir,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 mod clap_args;
 mod file_provider_config;
@@ -20,6 +20,8 @@ pub struct GlobalConfig {
     pub log_level: Option<LogLevel>,
     #[serde(default)]
     pub log_file: Vec<String>,
+    #[serde(default)]
+    pub cache_dir: Option<Arc<String>>,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/src/file_provider/from_config.rs
+++ b/src/file_provider/from_config.rs
@@ -18,6 +18,7 @@ fn serde_json_value_to_string(value: serde_json::Value) -> anyhow::Result<String
 }
 
 pub async fn build_file_provider(
+    cache_dir: Option<Arc<String>>,
     config: HashMap<String, crate::config::FileProviderConfig>,
 ) -> anyhow::Result<HashMap<String, Arc<dyn FileProvider>>> {
     let mut res = HashMap::new();
@@ -30,7 +31,7 @@ pub async fn build_file_provider(
                         s3_builder.with_config(key.into(), serde_json_value_to_string(value)?)
                 }
 
-                Arc::new(AwsS3FileProvider::new(s3_builder).await?)
+                Arc::new(AwsS3FileProvider::new(cache_dir.clone(), s3_builder).await?)
             }
             crate::config::FileProviderConfig::GoogleCloudStorage(keys) => {
                 let mut gcp_builder = object_store::gcp::GoogleCloudStorageBuilder::new();
@@ -39,7 +40,7 @@ pub async fn build_file_provider(
                         gcp_builder.with_config(key.into(), serde_json_value_to_string(value)?)
                 }
 
-                Arc::new(GoogleCouldStorageFileProvider::new(gcp_builder).await?)
+                Arc::new(GoogleCouldStorageFileProvider::new(cache_dir.clone(), gcp_builder).await?)
             }
         };
         res.insert(name, provider);

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,10 +43,12 @@ async fn main() -> anyhow::Result<()> {
         file_provider,
         playlists,
         outputs,
+        cache_dir,
         ..
     } = config::GlobalConfig::from_clap_args(config).await?;
 
-    let file_provider = Arc::new(file_provider::build_file_provider(file_provider).await?);
+    let file_provider =
+        Arc::new(file_provider::build_file_provider(cache_dir, file_provider).await?);
     let playlists = build_playlist_from_config(playlists, file_provider).await?;
 
     let mut outputs_map = HashMap::new();


### PR DESCRIPTION
- Add `cache_dir` field to GlobalConfig
- Update AWS and GCP file providers to use optional cache directory
- Modify CacheBuilder to handle custom cache directory
- Update README with new configuration fields